### PR TITLE
Expose shop and language identifiers for orders

### DIFF
--- a/src/ApiPlatform/Resources/Order/Order.php
+++ b/src/ApiPlatform/Resources/Order/Order.php
@@ -44,6 +44,8 @@ use Symfony\Component\HttpFoundation\Response;
                 '[prices][totalPaidTaxExcluded]' => '[totalPaidTaxExcl]',
                 '[prices][productsTotal]' => '[totalProductsTaxIncl]',
                 '[prices][productsTotalTaxExcluded]' => '[totalProductsTaxExcl]',
+                '[shopId]' => '[shopId]',
+                '[customer][languageId]' => '[langId]',
                 '[customer][id]' => '[customerId]',
                 '[customer][email]' => '[customerEmail]',
                 '[customer][fullName]' => '[customerName]',
@@ -95,6 +97,12 @@ class Order
 
     /** @var int */
     public int $statusId;
+
+    /** @var int */
+    public int $shopId;
+
+    /** @var int */
+    public int $langId;
 
     /** @var string */
     public string $currencyIso;

--- a/src/ApiPlatform/Resources/Order/OrderList.php
+++ b/src/ApiPlatform/Resources/Order/OrderList.php
@@ -71,6 +71,12 @@ class OrderList
     /** @var int */
     public int $statusId;
 
+    /** @var int */
+    public int $shopId;
+
+    /** @var int */
+    public int $langId;
+
     /** @var string */
     public string $currencyIso;
 

--- a/src/ApiPlatform/Resources/Order/State/OrderProvider.php
+++ b/src/ApiPlatform/Resources/Order/State/OrderProvider.php
@@ -108,6 +108,9 @@ class OrderProvider implements ProviderInterface
         $view->reference = (string) $order->reference;
         $view->statusId = (int) $order->current_state;
 
+        $view->shopId = (int) $order->id_shop;
+        $view->langId = (int) $order->id_lang;
+
         $state = new \OrderState($order->current_state, (int) $order->id_lang);
         $view->status = \Validate::isLoadedObject($state) ? (string) $state->name : '';
 


### PR DESCRIPTION
## Summary
- expose `shopId` and `langId` on order resources
- map shop and language IDs in order provider and CQRS mappings
