### PR TITLE
feat: expose order creation endpoint via API platform

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderCreation.php
+++ b/src/ApiPlatform/Resources/Order/OrderCreation.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/orders',
+            scopes: ['order_write'],
+            CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\AddOrderFromBackOfficeCommand::class,
+            CQRSCommandMapping: [
+                '[value]' => '[orderId]',
+            ],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        \PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderCreation
+{
+    #[ApiProperty(identifier: true, writable: false)]
+    public int $orderId;
+
+    public int $cartId;
+
+    public int $employeeId;
+
+    public string $orderMessage;
+
+    public string $paymentModuleName;
+
+    public int $orderStateId;
+}
+


### PR DESCRIPTION
## Summary
- add OrderCreation resource to expose AddOrderFromBackOfficeCommand
- allow creating orders through POST /orders
- cover order creation flow with functional test