### PR TITLE
feat: allow adding cart rules to orders

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderCartRule.php
+++ b/src/ApiPlatform/Resources/Order/OrderCartRule.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Module\APIResources\ApiPlatform\Serializer\Callbacks;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPost;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSPost(
+            uriTemplate: '/order/{orderId}/cart-rules',
+            requirements: ['orderId' => '\\d+'],
+            scopes: ['order_write'],
+            CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\AddCartRuleToOrderCommand::class,
+            CQRSCommandMapping: [
+                '[orderId]' => '[orderId]',
+                '[cartRuleId]' => '[cartRuleId]',
+                '[amount]' => '[amount]',
+            ],
+            openapiContext: [
+                'summary' => 'Add cart rule to order',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    denormalizationContext: [
+        'skip_null_values' => false,
+        'disable_type_enforcement' => true,
+        'callbacks' => [
+            'orderId' => [Callbacks::class, 'toInt'],
+            'cartRuleId' => [Callbacks::class, 'toInt'],
+        ],
+    ],
+    exceptionToStatus: [
+        \PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        \PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException::class => Response::HTTP_NOT_FOUND,
+        \Symfony\Component\Serializer\Exception\NotNormalizableValueException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+/**
+ * API Resource handling the addition of cart rules (vouchers) to orders.
+ */
+class OrderCartRule
+{
+    /**
+     * @var int|null Cart rule identifier
+     */
+    public ?int $cartRuleId = null;
+
+    /**
+     * @var string|null Discount amount applied to order
+     */
+    public ?string $amount = null;
+}


### PR DESCRIPTION
## Summary
- expose endpoint to attach cart rules to orders
- document operation in OpenAPI
- cover voucher addition with integration test
