### PR TITLE
chore: enable strict types

### DIFF
--- a/src/ApiPlatform/Resources/Attribute/AttributeGroup.php
+++ b/src/ApiPlatform/Resources/Attribute/AttributeGroup.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/ApiPlatform/Resources/Attribute/AttributeGroupList.php
+++ b/src/ApiPlatform/Resources/Attribute/AttributeGroupList.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/ApiPlatform/Resources/Attribute/BulkAttributeGroups.php
+++ b/src/ApiPlatform/Resources/Attribute/BulkAttributeGroups.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/ApiPlatform/Resources/Discount/Discount.php
+++ b/src/ApiPlatform/Resources/Discount/Discount.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/ApiPlatform/Resources/Discount/DiscountList.php
+++ b/src/ApiPlatform/Resources/Discount/DiscountList.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/ApiPlatform/Resources/Module/ResetModule.php
+++ b/src/ApiPlatform/Resources/Module/ResetModule.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/ApiPlatform/Resources/Module/UninstallModule.php
+++ b/src/ApiPlatform/Resources/Module/UninstallModule.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/ApiPlatform/Resources/Module/UploadModule.php
+++ b/src/ApiPlatform/Resources/Module/UploadModule.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/ApiPlatform/Resources/Product/ProductShops.php
+++ b/src/ApiPlatform/Resources/Product/ProductShops.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/List/ModuleGridDataFactory.php
+++ b/src/List/ModuleGridDataFactory.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA


### PR DESCRIPTION
## Summary
- enable strict types for API resource classes

## Testing
- `composer run-module-tests` (fails: Failed opening required '/tmp/prestashop-api-resources/vendor/smarty/smarty/libs/functions.php')

------
https://chatgpt.com/codex/tasks/task_e_68b7ff3d233c83259036e2c294c1043a