### PR TITLE
Place license block immediately after PHP tag

### DIFF
--- a/src/ApiPlatform/Resources/Customer/CustomerGroup.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerGroup.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/ApiPlatform/Resources/Customer/CustomerGroupList.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerGroupList.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/ApiPlatform/Resources/Hook.php
+++ b/src/ApiPlatform/Resources/Hook.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/src/ApiPlatform/Resources/Product/ProductList.php
+++ b/src/ApiPlatform/Resources/Product/ProductList.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/tests/Integration/ApiPlatform/CustomerGroupEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerGroupEndpointTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/tests/Integration/ApiPlatform/HookEndpointTest.php
+++ b/tests/Integration/ApiPlatform/HookEndpointTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA


### PR DESCRIPTION
## Summary
- ensure license header directly follows `<?php`
- keep single blank line before `declare(strict_types=1);`
