### PR TITLE
feat: filter orders by updated date

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderList.php
+++ b/src/ApiPlatform/Resources/Order/OrderList.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
 
-use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\ApiProperty;
-use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\Module\APIResources\ApiPlatform\Resources\Order\State\OrderProvider;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
 use Symfony\Component\HttpFoundation\Response;
 
 #[ApiResource(
@@ -36,6 +36,56 @@ use Symfony\Component\HttpFoundation\Response;
             scopes: ['order_read'],
             openapiContext: [
                 'summary' => 'List orders',
+                'parameters' => [
+                    [
+                        'name' => 'date_from',
+                        'in' => 'query',
+                        'required' => false,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                    [
+                        'name' => 'date_to',
+                        'in' => 'query',
+                        'required' => false,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                    [
+                        'name' => 'updated_from',
+                        'in' => 'query',
+                        'required' => false,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                    [
+                        'name' => 'updated_to',
+                        'in' => 'query',
+                        'required' => false,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                    [
+                        'name' => 'status_id',
+                        'in' => 'query',
+                        'required' => false,
+                        'schema' => [
+                            'type' => 'int',
+                        ],
+                    ],
+                    [
+                        'name' => 'q',
+                        'in' => 'query',
+                        'required' => false,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
             ],
         ),
         new PaginatedList(
@@ -92,5 +142,3 @@ class OrderList
     /** @var string ISO 8601 */
     public string $dateAdd;
 }
-
-

--- a/src/ApiPlatform/Resources/Order/State/OrderProvider.php
+++ b/src/ApiPlatform/Resources/Order/State/OrderProvider.php
@@ -56,6 +56,8 @@ class OrderProvider implements ProviderInterface
         $filters = $context['filters'] ?? [];
         $dateFrom = $filters['date_from'] ?? null;
         $dateTo = $filters['date_to'] ?? null;
+        $updatedFrom = $filters['updated_from'] ?? null;
+        $updatedTo = $filters['updated_to'] ?? null;
         $statusId = isset($filters['status_id']) ? (int) $filters['status_id'] : null;
         $query = $filters['q'] ?? null; // email or order reference
 
@@ -65,6 +67,12 @@ class OrderProvider implements ProviderInterface
         }
         if ($dateTo) {
             $where[] = "o.date_add <= '" . pSQL($dateTo) . "'";
+        }
+        if ($updatedFrom) {
+            $where[] = "o.date_upd >= '" . pSQL($updatedFrom) . "'";
+        }
+        if ($updatedTo) {
+            $where[] = "o.date_upd <= '" . pSQL($updatedTo) . "'";
         }
         if ($statusId) {
             $where[] = 'o.current_state = ' . (int) $statusId;


### PR DESCRIPTION
## Summary
- allow `updated_from` and `updated_to` filters in order list provider
- document new query parameters on `/orders` endpoint