### PR TITLE
feat: add endpoint to resend order emails

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderResendEmail.php
+++ b/src/ApiPlatform/Resources/Order/OrderResendEmail.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Module\APIResources\ApiPlatform\Serializer\Callbacks;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPost;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSPost(
+            uriTemplate: '/order/{orderId}/resend-email',
+            requirements: ['orderId' => '\\d+'],
+            scopes: ['order_write'],
+            CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\ResendOrderEmailCommand::class,
+            CQRSCommandMapping: [
+                '[orderId]' => '[orderId]',
+                '[statusId]' => '[orderStatusId]',
+                '[historyId]' => '[orderHistoryId]',
+            ],
+            openapiContext: [
+                'summary' => 'Resend order email',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    denormalizationContext: [
+        'skip_null_values' => false,
+        'disable_type_enforcement' => true,
+        'callbacks' => [
+            'orderId' => [Callbacks::class, 'toInt'],
+            'statusId' => [Callbacks::class, 'toInt'],
+            'historyId' => [Callbacks::class, 'toInt'],
+        ],
+    ],
+    exceptionToStatus: [
+        \PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        \PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException::class => Response::HTTP_NOT_FOUND,
+        \Symfony\Component\Serializer\Exception\NotNormalizableValueException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+/**
+ * API Resource handling resending order emails.
+ */
+class OrderResendEmail
+{
+    /** @var int|null Order status identifier */
+    public ?int $statusId = null;
+
+    /** @var int|null Order history identifier */
+    public ?int $historyId = null;
+}


### PR DESCRIPTION
## Summary
- expose POST /order/{orderId}/resend-email to trigger ResendOrderEmailCommand
- cover new endpoint with integration tests
