### PR TITLE
Add bulk order status endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/BulkOrderStatus.php
+++ b/src/ApiPlatform/Resources/Order/BulkOrderStatus.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Module\APIResources\ApiPlatform\Serializer\Callbacks;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPost;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSPost(
+            uriTemplate: '/orders/status-bulk',
+            output: false,
+            CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\BulkChangeOrderStatusCommand::class,
+            scopes: ['order_write'],
+            CQRSCommandMapping: [
+                '[orderIds]' => '[orderIds]',
+                '[statusId]' => '[newOrderStatusId]',
+            ],
+            openapiContext: [
+                'summary' => 'Bulk update order status',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    denormalizationContext: [
+        'skip_null_values' => false,
+        'disable_type_enforcement' => true,
+        'callbacks' => [
+            'orderIds' => [Callbacks::class, 'toIntArray'],
+            'statusId' => [Callbacks::class, 'toInt'],
+        ],
+    ],
+    exceptionToStatus: [
+        \PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException::class => Response::HTTP_NOT_FOUND,
+        \Symfony\Component\Serializer\Exception\NotNormalizableValueException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkOrderStatus
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 2]])]
+    #[Assert\Count(min: 1)]
+    #[Assert\All([
+        new Assert\Type('int'),
+        new Assert\Positive(),
+    ])]
+    public array $orderIds = [];
+
+    /**
+     * @var int
+     */
+    #[Assert\NotBlank]
+    #[Assert\Type('int')]
+    #[Assert\Positive]
+    public int $statusId;
+}
+

--- a/src/ApiPlatform/Serializer/Callbacks.php
+++ b/src/ApiPlatform/Serializer/Callbacks.php
@@ -37,6 +37,26 @@ final class Callbacks
     }
 
     /**
+     * Cast array of values to integers, signature matches Symfony Serializer callbacks.
+     *
+     * @param mixed $value
+     * @param mixed $object
+     * @param mixed $attribute
+     * @param mixed $format
+     * @param mixed $context
+     *
+     * @return int[]
+     */
+    public static function toIntArray($value, $object = null, $attribute = null, $format = null, $context = null): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_map(static fn ($item) => (int) $item, $value);
+    }
+
+    /**
      * Convert associative array of order detail identifiers to cancellation payload.
      *
      * Example input: ["5" => 2] becomes [["orderDetailId" => 5, "quantity" => 2]].


### PR DESCRIPTION
## Summary
- add serializer helper to cast ID arrays to integers
- expose POST /orders/status-bulk mapping to BulkChangeOrderStatusCommand
- cover bulk order status change with integration tests
