### PR TITLE
chore: pluralize order endpoint paths

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderAddress.php
+++ b/src/ApiPlatform/Resources/Order/OrderAddress.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSPartialUpdate(
-            uriTemplate: '/order/{orderId}/delivery-address',
+            uriTemplate: '/orders/{orderId}/delivery-address',
             requirements: ['orderId' => '\\d+'],
             scopes: ['order_write'],
             CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderDeliveryAddressCommand::class,
@@ -41,7 +41,7 @@ use Symfony\Component\HttpFoundation\Response;
             allowEmptyBody: false,
         ),
         new CQRSPartialUpdate(
-            uriTemplate: '/order/{orderId}/invoice-address',
+            uriTemplate: '/orders/{orderId}/invoice-address',
             requirements: ['orderId' => '\\d+'],
             scopes: ['order_write'],
             CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderInvoiceAddressCommand::class,

--- a/src/ApiPlatform/Resources/Order/OrderCartRule.php
+++ b/src/ApiPlatform/Resources/Order/OrderCartRule.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSPost(
-            uriTemplate: '/order/{orderId}/cart-rules',
+            uriTemplate: '/orders/{orderId}/cart-rules',
             requirements: ['orderId' => '\\d+'],
             scopes: ['order_write'],
             CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\AddCartRuleToOrderCommand::class,

--- a/src/ApiPlatform/Resources/Order/OrderCurrency.php
+++ b/src/ApiPlatform/Resources/Order/OrderCurrency.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSPartialUpdate(
-            uriTemplate: '/order/{orderId}/currency',
+            uriTemplate: '/orders/{orderId}/currency',
             requirements: ['orderId' => '\\d+'],
             scopes: ['order_write'],
             CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderCurrencyCommand::class,

--- a/src/ApiPlatform/Resources/Order/OrderNote.php
+++ b/src/ApiPlatform/Resources/Order/OrderNote.php
@@ -23,14 +23,14 @@ declare(strict_types=1);
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
 
 use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Module\APIResources\ApiPlatform\Serializer\Callbacks;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use Symfony\Component\HttpFoundation\Response;
-use PrestaShop\Module\APIResources\ApiPlatform\Serializer\Callbacks;
 
 #[ApiResource(
     operations: [
         new CQRSPartialUpdate(
-            uriTemplate: '/order/{orderId}/note',
+            uriTemplate: '/orders/{orderId}/note',
             requirements: ['orderId' => '\\d+'],
             scopes: ['order_write'],
             CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\SetInternalOrderNoteCommand::class,

--- a/src/ApiPlatform/Resources/Order/OrderProductCancellation.php
+++ b/src/ApiPlatform/Resources/Order/OrderProductCancellation.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSPost(
-            uriTemplate: '/order/{orderId}/cancellations',
+            uriTemplate: '/orders/{orderId}/cancellations',
             requirements: ['orderId' => '\\d+'],
             scopes: ['order_write'],
             CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\CancelOrderProductCommand::class,

--- a/src/ApiPlatform/Resources/Order/OrderRefund.php
+++ b/src/ApiPlatform/Resources/Order/OrderRefund.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSPost(
-            uriTemplate: '/order/{orderId}/refunds',
+            uriTemplate: '/orders/{orderId}/refunds',
             requirements: ['orderId' => '\\d+'],
             scopes: ['order_write'],
             CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\IssueStandardRefundCommand::class,

--- a/src/ApiPlatform/Resources/Order/OrderResendEmail.php
+++ b/src/ApiPlatform/Resources/Order/OrderResendEmail.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSPost(
-            uriTemplate: '/order/{orderId}/resend-email',
+            uriTemplate: '/orders/{orderId}/resend-email',
             requirements: ['orderId' => '\\d+'],
             scopes: ['order_write'],
             CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\ResendOrderEmailCommand::class,

--- a/src/ApiPlatform/Resources/Order/OrderStatus.php
+++ b/src/ApiPlatform/Resources/Order/OrderStatus.php
@@ -23,15 +23,15 @@ declare(strict_types=1);
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
 
 use ApiPlatform\Metadata\ApiResource;
-use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use PrestaShop\Module\APIResources\ApiPlatform\Serializer\Callbacks;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
         new CQRSPartialUpdate(
-            uriTemplate: '/order/{orderId}/status',
+            uriTemplate: '/orders/{orderId}/status',
             requirements: ['orderId' => '\\d+'],
             scopes: ['order_write'],
             CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderStatusCommand::class,
@@ -59,7 +59,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * API Resource handling the order status update action.
  */
 #[Assert\Expression(
-    "this.statusId !== null || this.statusCode !== null",
+    'this.statusId !== null || this.statusCode !== null',
     message: 'Either statusId or statusCode must be provided'
 )]
 class OrderStatus
@@ -111,5 +111,3 @@ class OrderStatus
         return $id;
     }
 }
-
-

--- a/src/ApiPlatform/Resources/Order/OrderTracking.php
+++ b/src/ApiPlatform/Resources/Order/OrderTracking.php
@@ -23,14 +23,14 @@ declare(strict_types=1);
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
 
 use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Module\APIResources\ApiPlatform\Serializer\Callbacks;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use Symfony\Component\HttpFoundation\Response;
-use PrestaShop\Module\APIResources\ApiPlatform\Serializer\Callbacks;
 
 #[ApiResource(
     operations: [
         new CQRSPartialUpdate(
-            uriTemplate: '/order/{orderId}/tracking',
+            uriTemplate: '/orders/{orderId}/tracking',
             requirements: ['orderId' => '\\d+'],
             scopes: ['order_write'],
             CQRSCommand: \PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCommand::class,
@@ -86,5 +86,3 @@ class OrderTracking
     /** @var string|null Tracking URL */
     public ?string $url = null;
 }
-
-

--- a/tests/Integration/ApiPlatform/OrderEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderEndpointTest.php
@@ -49,23 +49,23 @@ class OrderEndpointTest extends ApiTestCase
         ];
         yield 'add cart rule to order' => [
             'POST',
-            '/order/1/cart-rules',
+            '/orders/1/cart-rules',
         ];
         yield 'update order note' => [
             'PATCH',
-            '/order/1/note',
+            '/orders/1/note',
         ];
         yield 'resend order email' => [
             'POST',
-            '/order/1/resend-email',
+            '/orders/1/resend-email',
         ];
         yield 'cancel order products' => [
             'POST',
-            '/order/1/cancellations',
+            '/orders/1/cancellations',
         ];
         yield 'issue order refund' => [
             'POST',
-            '/order/1/refunds',
+            '/orders/1/refunds',
         ];
         yield 'bulk update order status' => [
             'POST',
@@ -143,7 +143,7 @@ class OrderEndpointTest extends ApiTestCase
             $deliveredId = (int) \Configuration::get($deliveredCode);
         }
 
-        $this->partialUpdateItem('/order/' . $orderId . '/status', [
+        $this->partialUpdateItem('/orders/' . $orderId . '/status', [
             'statusId' => $originalStatusId,
             'statusCode' => $deliveredCode,
         ], ['order_write'], Response::HTTP_NO_CONTENT);
@@ -152,21 +152,21 @@ class OrderEndpointTest extends ApiTestCase
         $this->assertEquals($deliveredId, (int) $updatedOrder->current_state);
 
         // Restore original status to avoid side effects
-        $this->partialUpdateItem('/order/' . $orderId . '/status', [
+        $this->partialUpdateItem('/orders/' . $orderId . '/status', [
             'statusId' => $originalStatusId,
         ], ['order_write'], Response::HTTP_NO_CONTENT);
     }
 
     public function testPatchStatusOrderNotFound(): void
     {
-        $this->partialUpdateItem('/order/999999/status', [
+        $this->partialUpdateItem('/orders/999999/status', [
             'statusId' => 1,
         ], ['order_write'], Response::HTTP_NOT_FOUND);
     }
 
     public function testPatchTrackingOrderNotFound(): void
     {
-        $this->partialUpdateItem('/order/999999/tracking', [
+        $this->partialUpdateItem('/orders/999999/tracking', [
             'number' => 'TRACK-001',
         ], ['order_write'], Response::HTTP_NOT_FOUND);
     }
@@ -174,7 +174,7 @@ class OrderEndpointTest extends ApiTestCase
     public function testPatchOrderNote(): void
     {
         $note = 'Internal note';
-        $this->partialUpdateItem('/order/1/note', [
+        $this->partialUpdateItem('/orders/1/note', [
             'note' => $note,
         ], ['order_write'], Response::HTTP_NO_CONTENT);
 
@@ -184,7 +184,7 @@ class OrderEndpointTest extends ApiTestCase
 
     public function testPatchOrderNoteNotFound(): void
     {
-        $this->partialUpdateItem('/order/999999/note', [
+        $this->partialUpdateItem('/orders/999999/note', [
             'note' => 'irrelevant',
         ], ['order_write'], Response::HTTP_NOT_FOUND);
     }
@@ -200,21 +200,21 @@ class OrderEndpointTest extends ApiTestCase
             $this->markTestSkipped('Target currency not available');
         }
 
-        $this->partialUpdateItem('/order/1/currency', [
+        $this->partialUpdateItem('/orders/1/currency', [
             'currencyId' => $newCurrency,
         ], ['order_write'], Response::HTTP_NO_CONTENT);
 
         $updatedOrder = new \Order(1);
         $this->assertEquals($newCurrency, (int) $updatedOrder->id_currency);
 
-        $this->partialUpdateItem('/order/1/currency', [
+        $this->partialUpdateItem('/orders/1/currency', [
             'currencyId' => $originalCurrency,
         ], ['order_write'], Response::HTTP_NO_CONTENT);
     }
 
     public function testPatchOrderCurrencyNotFound(): void
     {
-        $this->partialUpdateItem('/order/999999/currency', [
+        $this->partialUpdateItem('/orders/999999/currency', [
             'currencyId' => 1,
         ], ['order_write'], Response::HTTP_NOT_FOUND);
     }
@@ -235,7 +235,7 @@ class OrderEndpointTest extends ApiTestCase
         $order = $this->getItem('/orders/1', ['order_read']);
         $totalBefore = (float) $order['totalPaidTaxIncl'];
 
-        $this->createItem('/order/1/cart-rules', [
+        $this->createItem('/orders/1/cart-rules', [
             'cartRuleId' => $discount['discountId'],
             'amount' => '1.00',
         ], ['order_write'], Response::HTTP_NO_CONTENT);
@@ -251,7 +251,7 @@ class OrderEndpointTest extends ApiTestCase
             'SELECT id_order_history, id_order_state FROM `' . _DB_PREFIX_ . "order_history` WHERE id_order = $orderId ORDER BY id_order_history DESC"
         );
 
-        $this->createItem('/order/' . $orderId . '/resend-email', [
+        $this->createItem('/orders/' . $orderId . '/resend-email', [
             'statusId' => (int) $row['id_order_state'],
             'historyId' => (int) $row['id_order_history'],
         ], ['order_write'], Response::HTTP_NO_CONTENT);
@@ -259,7 +259,7 @@ class OrderEndpointTest extends ApiTestCase
 
     public function testResendOrderEmailOrderNotFound(): void
     {
-        $this->createItem('/order/999999/resend-email', [
+        $this->createItem('/orders/999999/resend-email', [
             'statusId' => 1,
             'historyId' => 1,
         ], ['order_write'], Response::HTTP_NOT_FOUND);
@@ -303,7 +303,7 @@ class OrderEndpointTest extends ApiTestCase
         $orderDetailId = (int) $order['items'][0]['orderDetailId'];
         $totalBefore = (float) $order['totalPaidTaxIncl'];
 
-        $this->createItem('/order/' . $orderId . '/cancellations', [
+        $this->createItem('/orders/' . $orderId . '/cancellations', [
             'items' => [
                 $orderDetailId => 1,
             ],
@@ -351,7 +351,7 @@ class OrderEndpointTest extends ApiTestCase
         $stockAfterOrder = \StockAvailable::getQuantityAvailableByProduct($productId);
         $this->assertEquals($stockBeforeOrder - $quantity, $stockAfterOrder);
 
-        $this->createItem('/order/' . $orderId . '/refunds', [
+        $this->createItem('/orders/' . $orderId . '/refunds', [
             'orderDetailRefunds' => [
                 $orderDetailId => 1,
             ],
@@ -370,7 +370,7 @@ class OrderEndpointTest extends ApiTestCase
 
     public function testIssueOrderRefundOrderNotFound(): void
     {
-        $this->createItem('/order/999999/refunds', [
+        $this->createItem('/orders/999999/refunds', [
             'orderDetailRefunds' => [1 => 1],
             'refundShippingCost' => false,
             'generateCreditSlip' => true,


### PR DESCRIPTION
## Summary
- use plural `/orders/{orderId}` in all order resource `uriTemplate`
- update integration tests to target new `/orders` routes
