### PR TITLE
refactor: inject query bus into order status resource

### DIFF
--- a/config/admin/services.yml
+++ b/config/admin/services.yml
@@ -33,3 +33,7 @@ services:
   PrestaShop\Module\APIResources\ApiPlatform\Resources\Order\State\OrderProcessor:
     arguments: []
     tags: ['api_platform.state_processor']
+
+  PrestaShop\Module\APIResources\ApiPlatform\Resources\Order\OrderStatus:
+    arguments:
+      $queryBus: '@prestashop.core.query_bus'


### PR DESCRIPTION
## Summary
- inject the query bus into `OrderStatus` to translate `statusCode` to `statusId` without static container access
- register the resource as a service so the bus is provided by the container

## Testing
- `PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --dry-run --diff src/ApiPlatform/Resources/Order/OrderStatus.php`
- `composer run-script run-module-tests` *(fails: Failed opening required '/tmp/prestashop-api-resources/vendor/smarty/smarty/libs/functions.php')*

------
https://chatgpt.com/codex/tasks/task_e_68bd86e3bd188325ad1c281c560be40a