### PR TITLE
Add validation constraints to Order creation DTO

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderCreation.php
+++ b/src/ApiPlatform/Resources/Order/OrderCreation.php
@@ -26,6 +26,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
@@ -48,14 +49,18 @@ class OrderCreation
     #[ApiProperty(identifier: true, writable: false)]
     public int $orderId;
 
+    #[Assert\NotBlank]
     public int $cartId;
 
+    #[Assert\NotBlank]
     public int $employeeId;
 
     public string $orderMessage;
 
+    #[Assert\NotBlank]
     public string $paymentModuleName;
 
+    #[Assert\NotBlank]
     public int $orderStateId;
 }
 


### PR DESCRIPTION
## Summary
- ensure required order creation fields are not blank

## Testing
- `php phpstan.phar analyse src/ApiPlatform/Resources/Order/OrderCreation.php --level=max` *(fails: attribute and class not found due to missing autoload)*
- `php -l src/ApiPlatform/Resources/Order/OrderCreation.php`
