### PR TITLE
Use giftProductId for free gift discounts

### DIFF
--- a/src/ApiPlatform/Resources/Discount/Discount.php
+++ b/src/ApiPlatform/Resources/Discount/Discount.php
@@ -90,7 +90,7 @@ class Discount
     public ?DecimalNumber $amountDiscount;
     public int $currencyId;
     public bool $isTaxIncluded;
-    public int $productId;
+    public int $giftProductId;
     public array $combinations;
     public int $reductionProduct;
 

--- a/tests/Integration/ApiPlatform/DiscountEndpointTest.php
+++ b/tests/Integration/ApiPlatform/DiscountEndpointTest.php
@@ -123,7 +123,15 @@ class DiscountEndpointTest extends ApiTestCase
 
         $this->assertEquals($expectedDiscount, $discount);
         // Now test that the GET request returns the same expected result
-        $this->assertEquals($expectedDiscount, $this->getItem('/discount/' . $discountId, ['discount_read']));
+        $retrievedDiscount = $this->getItem('/discount/' . $discountId, ['discount_read']);
+        $this->assertEquals($expectedDiscount, $retrievedDiscount);
+
+        if (self::FREE_GIFT === $type && $data !== null) {
+            $this->assertArrayHasKey('giftProductId', $discount);
+            $this->assertArrayHasKey('giftProductId', $retrievedDiscount);
+            $this->assertSame($data['giftProductId'], $discount['giftProductId']);
+            $this->assertSame($data['giftProductId'], $retrievedDiscount['giftProductId']);
+        }
 
         return $discountId;
     }
@@ -150,17 +158,16 @@ class DiscountEndpointTest extends ApiTestCase
                     'percentDiscount' => 20.0,
                 ],
             ],
-            // todo: This one must be improved, the naming productId is not correct, it should be giftProductId
-            /*[
+            [
                 self::FREE_GIFT,
                 [
                     'en-US' => 'new free gift discount',
                     'fr-FR' => 'nouveau discount produit offert',
                 ],
                 [
-                    'productId' => 1,
+                    'giftProductId' => 1,
                 ],
-            ],*/
+            ],
             [
                 self::FREE_SHIPPING,
                 [


### PR DESCRIPTION
## Summary
- rename discount field to `giftProductId`
- enable free gift discount tests and assert gift linking
