### PR TITLE
Add license headers to Order resources

### DIFF
--- a/src/ApiPlatform/Resources/Order/BulkOrderStatus.php
+++ b/src/ApiPlatform/Resources/Order/BulkOrderStatus.php
@@ -12,6 +12,10 @@
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
 declare(strict_types=1);
@@ -76,4 +80,3 @@ class BulkOrderStatus
     #[Assert\Positive]
     public int $statusId;
 }
-

--- a/src/ApiPlatform/Resources/Order/Event/OrderStatusUpdatedEvent.php
+++ b/src/ApiPlatform/Resources/Order/Event/OrderStatusUpdatedEvent.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/Event/OrderTrackingUpdatedEvent.php
+++ b/src/ApiPlatform/Resources/Order/Event/OrderTrackingUpdatedEvent.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/Order.php
+++ b/src/ApiPlatform/Resources/Order/Order.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/OrderAddress.php
+++ b/src/ApiPlatform/Resources/Order/OrderAddress.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/OrderCartRule.php
+++ b/src/ApiPlatform/Resources/Order/OrderCartRule.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/OrderCreation.php
+++ b/src/ApiPlatform/Resources/Order/OrderCreation.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
@@ -63,4 +63,3 @@ class OrderCreation
     #[Assert\NotBlank]
     public int $orderStateId;
 }
-

--- a/src/ApiPlatform/Resources/Order/OrderCurrency.php
+++ b/src/ApiPlatform/Resources/Order/OrderCurrency.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/OrderList.php
+++ b/src/ApiPlatform/Resources/Order/OrderList.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/OrderNote.php
+++ b/src/ApiPlatform/Resources/Order/OrderNote.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/OrderProductCancellation.php
+++ b/src/ApiPlatform/Resources/Order/OrderProductCancellation.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/OrderRefund.php
+++ b/src/ApiPlatform/Resources/Order/OrderRefund.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/OrderResendEmail.php
+++ b/src/ApiPlatform/Resources/Order/OrderResendEmail.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/OrderStatus.php
+++ b/src/ApiPlatform/Resources/Order/OrderStatus.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/OrderTracking.php
+++ b/src/ApiPlatform/Resources/Order/OrderTracking.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/State/OrderProcessor.php
+++ b/src/ApiPlatform/Resources/Order/State/OrderProcessor.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Resources/Order/State/OrderProvider.php
+++ b/src/ApiPlatform/Resources/Order/State/OrderProvider.php
@@ -13,7 +13,7 @@
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * @author    PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */

--- a/src/ApiPlatform/Serializer/Callbacks.php
+++ b/src/ApiPlatform/Serializer/Callbacks.php
@@ -12,6 +12,10 @@
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
 declare(strict_types=1);
@@ -121,5 +125,3 @@ final class Callbacks
         return $refunds;
     }
 }
-
-

--- a/tests/Integration/ApiPlatform/OrderEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderEndpointTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
-use Symfony\Component\HttpFoundation\Response;
 use PrestaShop\Module\APIResources\ApiPlatform\Resources\Order\Event\OrderTrackingUpdatedEvent;
+use Symfony\Component\HttpFoundation\Response;
 
 class OrderEndpointTest extends ApiTestCase
 {


### PR DESCRIPTION
## Summary
- add missing PrestaShop AFL headers to Order API resources, events and serializer helpers
- normalize use statements and remove trailing blank lines
